### PR TITLE
Updated to use ?format=json on all routes

### DIFF
--- a/maze/main.php
+++ b/maze/main.php
@@ -9,12 +9,21 @@ function reload() {
 }
 
 function redirect($redirect) {
-    header("Location: " . $redirect . "/");
+    header("Location: " . $redirect);
+}
+
+function refresh() {
+    header("Location: " . $_SERVER["REQUEST_URI"] . "?format=json");
 }
 
 $routing = new Routing();
 $rooms = new Rooms();
 $template = new Template();
+
+$tokens = $routing->getUriTokens();
+if (!isset($tokens["format"]) || $tokens["format"] !== "json") {
+    refresh();
+}
 
 $routes = $routing->getRoutesArray();
 if ($routes[0] !== "room" || (isset($routes[2]) && $routes[2] !== "door") ) {
@@ -32,7 +41,6 @@ if (isset($routes[2])) {
     if (empty($door)) {
         reload();
     }
-    $tokens = $routing->getUriTokens();
     if (isset($tokens["key"])) {
         $answer = $rooms->checkAnswer($tokens["key"], $door);
         if ($rooms->checkAnswer($tokens["key"], $door)) {


### PR DESCRIPTION
Hi @mindey, here is an updated version that forcibly sets all routes to use the key `format` and value `json`. From there we can extend that in the future.

With this update, if you don't add the query string `format=json` the app would add it as a default.